### PR TITLE
fix: change use of .Site.Language.Params.params -> .Site.Params

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,3 @@
 <small>
-  {{ .Site.Copyright }} | {{ markdownify .Site.Language.Params.params.madeWith }}
+  {{ .Site.Copyright }} | {{ markdownify .Site.Params.madeWith }}
 </small>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -4,7 +4,7 @@
 {{ with .Site.Social.email }}
 <a href='mailto:{{ . }}?subject={{ i18n "email-subject" }}"{{ default $.Site.Title $.Page.Title }}"'>Email</a>
 {{ end }}
-<a href="{{ .Site.Language.Params.params.blogPath }}/index.xml">RSS</a>
+<a href="{{ .Site.Params.blogPath }}/index.xml">RSS</a>
 
 <!-- Convert this page's translations into a dict -->
 {{ $translations := dict }}


### PR DESCRIPTION
.Site.Language.Params was deprecated in Hugo 0.112.0, see https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

This fixes the "Made with [Bear Cub](https://github.com/clente/hugo-bearcub)" footer text not appearing in the latest version of Hugo.