### PR TITLE
a11y: add a "skip to main content" link

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -145,3 +145,18 @@ h3.blog-filter {
   cursor: not-allowed;
   opacity: 0.7;
 }
+
+/*  "skip to main content"  link */
+.skiplink {
+  position: absolute;
+  top: 5;
+  transform: translateY(-600%);
+  transition: transform 0.5s;
+  background-color: #121212;
+  font-size: larger;
+  padding: 6px;
+}
+
+.skiplink:focus {
+  transform: translateY(0%);
+}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
   <header>
     {{- partial "header.html" . -}}
   </header>
-  <main>
+  <main id="maincontent">
     {{- block "main" . }}{{- end }}
   </main>
   <footer>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,2 +1,4 @@
+<a class="skiplink" href="#maincontent">Skip to Main Content</a>
+
 <a href="{{ relURL .Site.Home.Permalink }}" class="title"><h1>{{ .Site.Title }}</h1></a>
 <nav>{{- partial "nav.html" . -}}</nav>


### PR DESCRIPTION
The theme already has great accessibility but it could be improved even further with a "skip to main content" link. Basically, these skiplinks give people with screen readers and people who navigate websites only with their keyboards an easy way to skip the stuff that gets repeated on every page (in this case the title and navigation links in the header), so that they can get to the content right away

For more detailed overview you can see this if you want to: https://webaim.org/techniques/skipnav/

The skiplink in my pull request is visually hidden until it's focused so people who don't need it won't even know it's there