### PR TITLE
Update deprecated parameters use

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,3 +1,1 @@
-<small>
-  {{ .Site.Copyright }} | {{ markdownify .Site.Language.Params.params.madeWith }}
-</small>
+<small> {{ .Site.Copyright }} | {{ markdownify .Site.Params.madeWith }} </small>


### PR DESCRIPTION
This change was made from hugo's version 0.112.0 "The use of site.Language.Params is deprecated. Use site.Params directly"

More info here: https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120