### PR TITLE
Add `hideReply` functionality to pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,8 @@ enableRobotsTXT = true
     facebook_admin = "0000000000" # Facebook Page Admin ID
 
   # Author metadata. This is mostly used for the RSS feed of your site, but the
-  # email is also added to the footer of each post
+  # email is also added to the footer of each post. You can hide the "reply to"
+  # link by using a `hideReply` param in front matter.
   [params.author]
     name = "John Doe" # Your name as shown in the RSS feed metadata
     email = "me@example.com" # Added to the footer so readers can reply to posts

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,11 +16,13 @@
     <a class="blog-tags" href="{{ .RelPermalink }}">#{{ lower .LinkTitle }}</a>
   {{ end }}
 </p>
+{{ if not .Params.hideReply }}
 {{ with .Site.Params.author.email }}
   <p>
     <a href='mailto:{{ . }}?subject={{ i18n "email-subject" }}"{{ default $.Site.Title $.Page.Title }}"'>
       {{ i18n "email-reply" }} ↪
     </a>
   </p>
+{{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
## Usage

Set the `hideReply` param on front matter to completely remove the "reply to" link present in the bottom of some page. This is backwards-compatible given that any page that does not have the `hideReply` param will continue to work as before.

```md
---
title: "Recommendations"
menu: "main"
weight: 3
hideReply: true
---
```

I chose to keep the formatting of the `layouts/_default/single.html` page as is, but I can reformat it to make it easier to read, just didn't want to go out of the scope of the PR. 

## Motivation

I had the need to disable the "reply to" link in one of my pages. For my use case I created a override on the default layout, but I think this is a feature that may be useful for someone else.

---

This is a very nice theme, thank you for your work on it! :smile: 
 