### PR TITLE
FIX - wrapping code block lines in original.css

### DIFF
--- a/assets/original.css
+++ b/assets/original.css
@@ -89,6 +89,7 @@ pre code {
   white-space: pre-wrap;
   font-size: 14px;
   overflow-x: auto;
+  text-wrap: nowrap;
 }
 
 blockquote {


### PR DESCRIPTION
The lines of the code blocks of the HTML get wrapped on small/mobile screens. 
Adding this line make the scrolling overflow functional again.
`herman.css` does not have this problem, so I guess this is the intended behaviour.

It doesn't seem that adding this line breaks anything else.

## Before
![wrapped](https://github.com/clente/hugo-bearcub/assets/122827520/0fde2af4-c65e-4bf2-8be3-160689c921c6)

## After
![fixed](https://github.com/clente/hugo-bearcub/assets/122827520/fc1fb804-58aa-4f07-bf87-5601bda3485e)
