### PR TITLE
Add estimated content time

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,6 +6,13 @@
     {{ .Date.Format (default "2006-01-02" .Site.Params.dateFormat) }}
   </time>
   {{ with .Params.author }}· {{.}}{{ end }}
+  {{ if and (.Site.Params.showContentTime) (not .Params.hideContentTime) }}
+    {{ if .Params.contentTime }}
+      {{ with .Params.contentTime }}· {{ printf "%d min" . }}{{end}}
+    {{ else }}
+      {{ with .ReadingTime }}· {{ printf "%d min" . }}{{end}}
+    {{ end }}
+  {{ end }}
 </p>
 {{ end }}
 <content>


### PR DESCRIPTION
This is an idea for the pages to show the time to go through the page based on either Hugo's own `ReadingTime` or a custom time set by the user (in case you are linking videos). It would show up as this, for example:

![image](https://github.com/clente/hugo-bearcub/assets/6443427/f478ddc7-00a4-43b1-8497-f20f9af4f9a2)

- You can disable/enable it for the entire project by doing `showContentTime = true/false` to the `config.toml`
- You can disable/enable it for the given post by adding `showContentTime = true/false` to the front matter
- You can override the calculated "reading time" by adding `contentTime = X` to the front matter

Let me know if that's something you'd like to merge and I can document it on the appropriate places
