### PR TITLE
fix stretched images

### DIFF
--- a/assets/original.css
+++ b/assets/original.css
@@ -75,6 +75,7 @@ td {
 
 img {
   max-width: 100%;
+  height: auto;
 }
 
 code {


### PR DESCRIPTION
When images are resized for size or performance reasons, the Herman theme properly resizes the image to keep the proper aspect ratio, due to it having the height: auto attribute on the img tag.

The original theme does not have this attribute.

Generating minimized images to reduce bandwidth and generating blog code such as this to present multiple options for images:
```
<img src="/blog/the_great_escape/the_great_escape.jpg" srcset="/blog/the_great_escape/the_great_escape_hu17533236072349824654.jpg 300w,/blog/the_great_escape/the_great_escape_hu9070565606537851499.jpg 500w,/blog/the_great_escape/the_great_escape_hu725608241782357191.jpg 700w" sizes="(max-width: 499px) 300px,(max-width: 699px) 500px,700px" alt="Baby me and our dog" title="Escaping from the playpen with an unlikely accomplice" loading="lazy" width="1920" height="1565">
```
Results in the image that is supposed to be 700x571 to be displayed as 700x1565
The max-with properly constrains the width so that it is 700 wide, not 1920, however without the height: auto attribute the height is not constrained and takes up the full 1565

Again this is already set in the Herman theme, I'm just trying to make both have this ability.