### PR TITLE
Update rich-content.md

### DIFF
--- a/exampleSite/content/blog/rich-content.md
+++ b/exampleSite/content/blog/rich-content.md
@@ -23,7 +23,7 @@ Hugo ships with several [Built-in Shortcodes](https://gohugo.io/content-manageme
 
 ## Twitter Simple Shortcode
 
-{{< tweet user="DesignReviewed" id="1085870671291310081" >}}
+{{< x user="DesignReviewed" id="1085870671291310081" >}}
 
 <br>
 


### PR DESCRIPTION
WARN  The "twitter", "tweet", and "twitter_simple" shortcodes were deprecated in v0.142.0 and will be removed in a future release. Please use the "x" shortcode instead.