### PR TITLE
Skip pages with rss: false in the frontmatter

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -57,7 +57,7 @@
     {{- with .OutputFormats.Get "RSS" }}
     {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
     {{- end }}
-    {{- range $pages }}
+    {{- range $pages }}{{ if ne .Params.rss false }}
     <item>
       <title>{{ .Title }}</title>
       <link>{{ .Permalink }}</link>


### PR DESCRIPTION
I have a few pages on my website that I don't want to include in my sites RSS feed, so I adjusted the RSS feed generation to allow for specifiying 'rss: false` in the frontmatter to skip certain pages. Here's an example of how I use it. Pages without the `rss` tag are included by default.

```YAML
---
title: "Favorites"
menu: "main"
weight: 4
rss: false
---
```
