### PR TITLE
fix: RSS link to respect multilingual setup

### DIFF
--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,7 +1,9 @@
 {{ range .Site.Menus.main.ByWeight }}
   <a href="{{ .URL }}">{{ .Name }}</a>
 {{ end }}
-<a href='{{ absURL "index.xml" }}'>RSS</a>
+{{ end }} {{ with .OutputFormats.Get "RSS" }}
+  <a href="{{ .RelPermalink }}">RSS</a>
+{{ end }}
 
 <!-- Convert this page's translations into a dict -->
 {{ $translations := dict }}


### PR DESCRIPTION
Currently, the RSS link in the navigation partial uses a fixed path (`index.xml`), which does not respect the site's multilingual configuration.  

This change updates the link to use Hugo's `.OutputFormats.Get "RSS"`, ensuring that the RSS link points to the correct language version of the feed.  

- Works correctly for both single-language and multi-language sites.
- Uses Hugo's built-in output formats for more robust handling of RSS links.

You can also see a working demo on my blog: https://blog.breno5g.dev/

Fixes #44 
